### PR TITLE
addressing Bugzilla to remove COMINOUT

### DIFF
--- a/dev/lsf_scripts/JGLWU_FORECAST.lsf
+++ b/dev/lsf_scripts/JGLWU_FORECAST.lsf
@@ -127,7 +127,6 @@ export COMINrst=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${mo
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 #added for restart files
 export COMOUTrst=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 

--- a/dev/lsf_scripts/JGLWU_LC_FORECAST.lsf
+++ b/dev/lsf_scripts/JGLWU_LC_FORECAST.lsf
@@ -141,7 +141,6 @@ export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${mode
 #added for restart files
 export COMOUTrst=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 
-export COMINOUT=$COMOUT
 
 export COMROOT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 #export DCOMROOT=/gpfs/${pref}p1/nco/GLWU_Danger_Seas/dcom

--- a/dev/lsf_scripts/JGLWU_LC_PGEN.lsf
+++ b/dev/lsf_scripts/JGLWU_LC_PGEN.lsf
@@ -125,7 +125,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 export COMOUTwmo=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}/wmo
 
 export DBNROOT=/dev/null

--- a/dev/lsf_scripts/JGLWU_LC_POST.lsf
+++ b/dev/lsf_scripts/JGLWU_LC_POST.lsf
@@ -125,7 +125,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 
 export COMROOT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 

--- a/dev/lsf_scripts/JGLWU_LC_PREP.lsf
+++ b/dev/lsf_scripts/JGLWU_LC_PREP.lsf
@@ -140,7 +140,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 #added for champlain
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 
 export COMROOT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 

--- a/dev/lsf_scripts/JGLWU_PGEN.lsf
+++ b/dev/lsf_scripts/JGLWU_PGEN.lsf
@@ -125,7 +125,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 export COMOUTwmo=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}/wmo
 
 export DBNROOT=/dev/null

--- a/dev/lsf_scripts/JGLWU_POST.lsf
+++ b/dev/lsf_scripts/JGLWU_POST.lsf
@@ -125,7 +125,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 
 export COMROOT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 

--- a/dev/lsf_scripts/JGLWU_PREP.lsf
+++ b/dev/lsf_scripts/JGLWU_PREP.lsf
@@ -144,7 +144,6 @@ export COMIN=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model
 
 export COMOUTwave=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 export COMOUT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}/${RUN}.${PDY}
-export COMINOUT=$COMOUT
 
 export COMROOT=/lfs/h2/emc/couple/noscrub/${runuser}/${GLWUdir}/com/${NET}/${model_ver}
 

--- a/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB.lsf
+++ b/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB.lsf
@@ -142,7 +142,6 @@ export COMIN=${COMIN:-${com}/${RUN}.${PDY}}
 export web=${web:-/gpfs/hps3/emc/marine/noscrub/${runuser}/${GLWUdir}/WEB}
 
 export COMOUT=${COMOUT:-${com}/${RUN}.${PDY}}
-export COMINOUT=${COMINOUT:-${com}/${RUN}.${PDY}}
 
 module load /gpfs/hps3/emc/marine/noscrub/Todd.Spindler/modulefiles/anaconda_no_mpi/1.0.0
 export PYTHON=`which python`

--- a/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB2.lsf
+++ b/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB2.lsf
@@ -147,7 +147,6 @@ export COMIN=${COMIN:-${com}/${RUN}.${PDY}}
 export web=${web:-/gpfs/hps3/emc/marine/noscrub/${runuser}/${GLWUdir}/WEB}
 
 export COMOUT=${COMOUT:-${com}/${RUN}.${PDY}}
-export COMINOUT=${COMINOUT:-${com}/${RUN}.${PDY}}
 
 export PYTHON=`which python`
 

--- a/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB3.lsf
+++ b/dev/lsf_scripts_plots_dangerseas/JGLWU_WEB3.lsf
@@ -116,7 +116,6 @@ export COMIN=${COMIN:-${com}/${RUN}.${PDY}}
 #export web=${web:-/gpfs/hps3/emc/marine/noscrub/${runuser}/${GLWUdir}/WEB}
 
 export COMOUT=${COMOUT:-${com}/${RUN}.${PDY}}
-export COMINOUT=${COMINOUT:-${com}/${RUN}.${PDY}}
 
 export PYTHON=`which python`
 

--- a/jobs/JGLWU_FORECAST
+++ b/jobs/JGLWU_FORECAST
@@ -44,7 +44,6 @@ export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
 #added for restart files
 export COMOUTrst=${COMOUTrst:-$(compath.py -v ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 
 
 if [ "$SENDCOM" = YES ]; then

--- a/jobs/JGLWU_LC_FORECAST
+++ b/jobs/JGLWU_LC_FORECAST
@@ -46,7 +46,6 @@ export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
 #added for restart files
 export COMOUTrst=${COMOUTrst:-$(compath.py -v ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 
 if [ "$SENDCOM" = YES ]; then
   mkdir -p $COMOUT

--- a/jobs/JGLWU_LC_PGEN
+++ b/jobs/JGLWU_LC_PGEN
@@ -41,7 +41,6 @@ export COMIN=${COMIN:-$(compath.py -v  ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v  ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwmo=${COMOUTwmo:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})/wmo}
 
 if [ "$SENDCOM" = YES ]; then

--- a/jobs/JGLWU_LC_POST
+++ b/jobs/JGLWU_LC_POST
@@ -41,7 +41,6 @@ export COMIN=${COMIN:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 
 if [ "$SENDCOM" = YES ]; then
   mkdir -p $COMOUT 

--- a/jobs/JGLWU_LC_PREP
+++ b/jobs/JGLWU_LC_PREP
@@ -48,7 +48,6 @@ export COMIN=${COMIN:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 
 if [ "$SENDCOM" = YES ]; then
   mkdir -p $COMOUT

--- a/jobs/JGLWU_PGEN
+++ b/jobs/JGLWU_PGEN
@@ -40,7 +40,6 @@ export COMIN=${COMIN:-$(compath.py -v  ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v  ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwmo=${COMOUTwmo:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})/wmo}
 
 if [ "$SENDCOM" = YES ]; then

--- a/jobs/JGLWU_POST
+++ b/jobs/JGLWU_POST
@@ -40,7 +40,6 @@ export COMIN=${COMIN:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 
 if [ "$SENDCOM" = YES ]; then
   mkdir -p $COMOUT 

--- a/jobs/JGLWU_PREP
+++ b/jobs/JGLWU_PREP
@@ -44,7 +44,6 @@ export COMIN=${COMIN:-$(compath.py -v ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMINwave=${COMINwave:-$(compath.py -v ${NET}/${model_ver})}
 export COMOUT=${COMOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 export COMOUTwave=${COMOUTwave:-$(compath.py -v -o ${NET}/${model_ver})}
-export COMINOUT=${COMINOUT:-$(compath.py -v -o ${NET}/${model_ver}/${RUN}.${PDY})}
 
 if [ "$SENDCOM" = YES ]; then
   mkdir -p $COMOUT


### PR DESCRIPTION
This PR will remove all "COMINOUT" references.

From SPA:
In GLWU v2.0.7, variable "COMINOUT" is defined in all J-jobs. However, it does
not appear to be used. 

Please remove this variable if it is not being used. If it is needed, please
rename it so that it clearly indicates whether it is input data or output data.